### PR TITLE
Update deprecated syntax for future rstan compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     methods,
     Rcpp (>= 0.12.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
+    rstan (>= 2.26.0),
     rstantools (>= 2.1.1),
     edstan, 
     numDeriv
@@ -43,8 +43,8 @@ LinkingTo:
     Rcpp (>= 0.12.0),
     RcppEigen (>= 0.3.3.3.0),
     RcppParallel (>= 5.0.1),
-    rstan (>= 2.18.1),
-    StanHeaders (>= 2.18.0)
+    rstan (>= 2.26.0),
+    StanHeaders (>= 2.26.0)
 SystemRequirements: GNU make
 Suggests: 
     knitr,

--- a/inst/stan/muppnocov.stan
+++ b/inst/stan/muppnocov.stan
@@ -54,12 +54,12 @@ data {
   int<lower=1> n_pair;
   int<lower=1> N;
   int<lower=1> n_dimension;
-  int<lower=0> p[n_pair, 2]; //p=pair specification map for the given pairs
-  int<lower=1, upper=2> y[N];
+  array[n_pair, 2] int<lower=0> p; //p=pair specification map for the given pairs
+  array[N] int<lower=1, upper=2> y;
   int<lower=1> I1;
   int<lower=1> J1;
-  int<lower=1, upper=I1> II[N];
-  int<lower=1, upper=J1> JJ[N];
+  array[N] int<lower=1, upper=I1> II;
+  array[N] int<lower=1, upper=J1> JJ;
 
   // user-defined priors
   real ma;
@@ -69,13 +69,13 @@ data {
   real mt;
   real vt;
 
-  int<lower=1> ind[2*N];  //pairs: 2*N  triplets: 3*N
+  array[2*N] int<lower=1> ind;  //pairs: 2*N  triplets: 3*N
   vector[n_dimension] theta_mu;
 }
 
 parameters {
 
-  vector[n_dimension] theta[n_student];
+  array[n_student] vector[n_dimension] theta;
   //matrix [n_student, n_dimension] theta;
   vector<lower=0, upper=4> [n_item] alpha;
   vector<lower=-5, upper=5> [n_item] delta;


### PR DESCRIPTION
Now that rstan 2.26 is available on CRAN we need to update the deprecated syntax in your package's Stan models, otherwise it will fail to install with an upcoming version of RStan. 

The following updates have been made:

- New array syntax

More information about the deprecated and removed syntax in Stan can be found here:
- https://mc-stan.org/docs/functions-reference/deprecated-functions.html
- https://mc-stan.org/docs/functions-reference/removed-functions.html

If you could merge and submit to CRAN soon, it would be greatly appreciated.

Let me know if you have any questions about these changes.

Thanks!
